### PR TITLE
Fix create address via ReST API

### DIFF
--- a/features/cerberusweb.restapi/api/rest/addresses.php
+++ b/features/cerberusweb.restapi/api/rest/addresses.php
@@ -42,9 +42,10 @@ class ChRest_Addresses extends Extension_RestController implements IExtensionRes
 			case 'search':
 				$this->postSearch();
 				break;
+			default:
+				$this->error(self::ERRNO_NOT_IMPLEMENTED);
+				break;
 		}
-		
-		$this->error(self::ERRNO_NOT_IMPLEMENTED);
 	}
 	
 	function deleteAction($stack) {


### PR DESCRIPTION
By always passing the not-implemented path, the rest API would execute the creation of an address, but would never return the results.
