### PR TITLE
Firefox truncating attachment name on space

### DIFF
--- a/features/cerberusweb.core/api/uri/files.php
+++ b/features/cerberusweb.core/api/uri/files.php
@@ -72,7 +72,7 @@ class ChFilesController extends DevblocksControllerExtension {
 // 		header("Last-Modified: " . gmdate("D, d M Y H:i:s") . " GMT");
 
 		if($is_download) {
-			header('Content-Disposition: attachment; filename=' . $file->name);
+			header("Content-Disposition: attachment; filename=\"" . $file->name . "\"");
 			
 		} else {
 			@$range = DevblocksPlatform::importGPC($_SERVER['HTTP_RANGE'], 'string', null);


### PR DESCRIPTION
When downloading an attachment with Mozilla Firefox, the filename was truncated to the first space. That changed worked for us, so it might come in handy. Anyways, submitting an issue making reference to this. Thanks!