### PR TITLE
[Tests] Switching to Headless Chrome for tests

### DIFF
--- a/tests/README.md
+++ b/tests/README.md
@@ -1,0 +1,25 @@
+# Running tests
+
+## Install Dependencies
+
+`$ cd tests`
+`$ composer install`
+
+## Install ChromeDriver for UI tests
+
+It's suggested to use Headless Chrome (the default) for running the UI tests. You need to install ChromeDriver for that, which can be done via Homebrew on macOS with the following:
+
+`$ brew install chromedriver`
+
+In a terminal window, you need to startup chromedriver with the following command before running tests:
+
+`$ chromedriver --port=4444`
+
+You can add `--verbose` if you want detailed logging from Chrome.
+
+## Running tests
+
+Initial DB install: `vendor/bin/phpunit -c phpunit.cerb.install.xml`
+
+UI tests: `vendor/bin/phpunit -c phpunit.cerb.eval.xml`
+

--- a/tests/bootstrap.eval.php
+++ b/tests/bootstrap.eval.php
@@ -1,6 +1,6 @@
 <?php
 // The URL to Selenium's WebDriver API
-define('WEBDRIVER_URL', 'http://localhost:4444/wd/hub');
+define('WEBDRIVER_URL', 'http://localhost:4444');
 
 // The URL where you installed Cerb
 define('BROWSER_URL', 'http://localhost:8080/index.php');
@@ -12,6 +12,9 @@ use Facebook\WebDriver\Remote\RemoteWebDriver;
 use Facebook\WebDriver\Exception\NoSuchElementException;
 use Facebook\WebDriver\WebDriverBy;
 use Facebook\WebDriver\WebDriverExpectedCondition;
+use Facebook\WebDriver\WebDriverDimension;
+use Facebook\WebDriver\Chrome\ChromeOptions;
+use Facebook\WebDriver\Remote\WebDriverBrowserType;
 
 require_once('vendor/autoload.php');
 
@@ -22,11 +25,24 @@ class CerbTestHelper {
 	static function getInstance() {
 		if(is_null(self::$_instance)) {
 			// Pick one:
-			$capabilities = DesiredCapabilities::safari();
+			//$capabilities = DesiredCapabilities::phantomjs();
+			//$capabilities = DesiredCapabilities::safari();
 			//$capabilities = DesiredCapabilities::firefox();
-			//$capabilities = DesiredCapabilities::chrome();
-			
+			$capabilities = DesiredCapabilities::chrome();
+
+			if($capabilities->getBrowserName() == WebDriverBrowserType::CHROME) {
+				$chromeOptions = new ChromeOptions();
+				$chromeOptions->addArguments(['--headless', 'window-size=1920,1080']);
+				$capabilities->setCapability(ChromeOptions::CAPABILITY, $chromeOptions);
+			}
+
 			$driver = RemoteWebDriver::create(WEBDRIVER_URL, $capabilities, 5000, 30000);
+
+			if($capabilities->getBrowserName() == WebDriverBrowserType::PHANTOMJS) {
+				$window = new WebDriverDimension(1024, 768);
+				$driver->manage()->window()->setSize($window);
+			}
+
 			//$driver->manage()->window()->maximize();
 			
 			self::$_instance = new CerbTestHelper();

--- a/tests/eval/CerbEval_UI_Setup.php
+++ b/tests/eval/CerbEval_UI_Setup.php
@@ -436,8 +436,10 @@ class CerbEval_UI_Setup extends CerbTestBase {
 			
 			$driver->executeScript(sprintf("$('div.minicolors ul.minicolors-swatches li:nth-child(%d)').click().parent().parent().hide();", $group['bgindex']));
 
-			$avatar_popup->findElement(WebDriverBy::name('initials'))
-				->sendKeys($group['emoji']);
+			// [JSJ] Headless Chrome doesn't support SMP unicode characters for sendKeys(), so we have to use jQuery to set the emoji
+			//$avatar_popup->findElement(WebDriverBy::name('initials'))
+			//	->sendKeys($group['emoji']);
+			$driver->executeScript(sprintf("$('body > div.ui-dialog:last-of-type input[name=\'initials\']').val('%s');", $group["emoji"]));
 			
 			$avatar_popup->findElement(WebDriverBy::cssSelector('fieldset.cerb-avatar-monogram button'))
 				->click();

--- a/tests/eval/CerbEval_UI_SimulateDay1.php
+++ b/tests/eval/CerbEval_UI_SimulateDay1.php
@@ -270,7 +270,7 @@ class CerbEval_UI_SimulateDay1 extends CerbTestBase {
 			function() use (&$driver) {
 				try {
 					$objects = $driver->findElements(WebDriverBy::cssSelector('#conversation > div'));
-					return 4 == count($objects);
+					return 4 <= count($objects);
 					
 				} catch (NoSuchElementException $nse) {
 					return null;


### PR DESCRIPTION
* Switches to using Headless Chrome for UI tests
* Fixes an issue where Headless Chrome doesn't support SMP unicode characters with sendKeys() by using executeScript() with jQuery instead
* Fixes an issue where the detection of the right number of conversation divs was incorrect on Chrome
* Also adds partial support for PhantomJS (some test cases won't run with PhantomJS)