### PR TITLE
[Login/Code Cleanup] fix for ipv6 IP addresses, causes php errors due…

### DIFF
--- a/install/extras/automation/cerb.setup.schema.sql
+++ b/install/extras/automation/cerb.setup.schema.sql
@@ -769,7 +769,7 @@ CREATE TABLE `devblocks_session` (
   `updated` int(10) unsigned NOT NULL DEFAULT '0',
   `session_data` mediumtext,
   `user_id` int(10) unsigned NOT NULL DEFAULT '0',
-  `user_ip` varchar(32) NOT NULL DEFAULT '',
+  `user_ip` varchar(39) NOT NULL DEFAULT '',
   `user_agent` varchar(255) NOT NULL DEFAULT '',
   `refreshed_at` int(10) unsigned NOT NULL DEFAULT '0',
   PRIMARY KEY (`session_key`),


### PR DESCRIPTION
Hi guys,

when installing on a web server running on IPv6 logins don't work because of the following:

UPDATE devblocks_session SET updated=xxxxx,user_ip="2407:7000:8858:8735:7d9a:3d86:2b68:55b6"

mysql column needs adjusting to 39 chars to fit those in.

Another approach would be to store IP addresses in binary in mysql, then extract them via INET_NTOA and INET6_NTOA.