### PR TITLE
Update custom_field.php

### DIFF
--- a/features/cerberusweb.core/api/dao/custom_field.php
+++ b/features/cerberusweb.core/api/dao/custom_field.php
@@ -2164,9 +2164,16 @@ class Context_CustomField extends Extension_DevblocksContext implements IDevbloc
 				
 			case 'params':
 				if(!is_array($value)) {
-					$error = 'must be an object.';
-					return false;
-				}
+                                        if(is_string($value)) {
+                                                if(false == ($value = json_decode($value))) {
+                                                        $error = "string could not be JSON decoded";
+                                                        return false;
+                                                }
+                                        } else {
+                                                $error = "must be an object.";
+                                                return false;
+                                        }
+                                }
 				
 				if(false == ($json = json_encode($value))) {
 					$error = 'could not be JSON encoded.';


### PR DESCRIPTION
Noticed (through the API) that if you try to update 'params' you receive an error: "must be an object." getDaoFieldsFromKeyAndValue expects an object it then encodes into JSON, but if you hand it already-encoded json, it doesn't recognize it.  This would both recognize and validate a json encoded string as input.