### PR TITLE
Fixed the double line feed on HTML lists.

### DIFF
--- a/libs/devblocks/Devblocks.class.php
+++ b/libs/devblocks/Devblocks.class.php
@@ -1387,13 +1387,15 @@ class DevblocksPlatform extends DevblocksEngine {
 		
 		foreach($lists as $list) { /* @var $list DOMElement */
 			$items = $xpath->query('./li', $list);
-			
+
+            $liCount = $items->length;
 			$counter = 1;
 			foreach($items as $item) { /* @var $item DOMElement */
 				if(false == (@$inner_html = $dom->saveXML($item)))
 					continue;
-				
-				$value = DevblocksPlatform::stripHTML($inner_html);
+
+                $value = rtrim(DevblocksPlatform::stripHTML($inner_html), "\n") .
+                    (($liCount != $counter) ? "\n" : '');
 				
 				$txt = $dom->createTextNode($counter++ . '. ' . str_replace("\n", "{{BR}}", $value));
 				$item->parentNode->insertBefore($txt, $item);
@@ -1407,16 +1409,20 @@ class DevblocksPlatform extends DevblocksEngine {
 		
 		foreach($lists as $list) { /* @var $list DOMElement */
 			$items = $xpath->query('./li', $list);
-			
+
+            $liCount = $items->length;
+            $counter = 1;
 			foreach($items as $item) { /* @var $item DOMElement */
 				if(false == (@$inner_html = $dom->saveXML($item)))
 					continue;
-				
-				$value = DevblocksPlatform::stripHTML($inner_html);
+
+                $value = rtrim(DevblocksPlatform::stripHTML($inner_html), "\n") .
+                    (($liCount != $counter) ? "\n" : '');
 				
 				$txt = $dom->createTextNode('- ' . str_replace("\n", "{{BR}}", $value));
 				$item->parentNode->insertBefore($txt, $item);
 				$item->parentNode->removeChild($item);
+                $counter++;
 			}
 		}
 		


### PR DESCRIPTION
When a markdown list is provided and HTML response is required:
- List item 1
- List Item 2
- List Item 3
Sends as "<ul><li>List item 1</li><li>List item 2</li><li>List item 3</li></ul>".
Stores as "- List item 1\n\n- List item 2\n\n- List item 3\n\n\n".
If storing as plain text, it will store as: "- List item 1\n- List item 2\n- List item 3".

This pull request removes the extra line feed from each list item so that the stored content is more consistent when using the raw content, such as with the API.