### PR TITLE
** worker -> settings: tabs

### DIFF
--- a/features/cerberusweb.core/templates/internal/profiles/tabs/worker/settings/settings.tpl
+++ b/features/cerberusweb.core/templates/internal/profiles/tabs/worker/settings/settings.tpl
@@ -6,7 +6,7 @@
 		
 		{foreach from=$list item=tab_name}
 		{$tabs[] = $tab_name}
-		<li data-alias="{$tab_name}"><a href="{devblocks_url}ajax.php?c=profiles&a=handleProfileTabAction&tab_id={$tab->id}&action=showSettingsSectionTab&worker_id={$worker->id}&tab={$tab_name}{/devblocks_url}">{$tab_name|devblocks_translate|capitalize}</a></li>
+		<li data-alias="{$tab_name}"><a href="{devblocks_url}ajax.php?c=profiles&a=handleProfileTabAction&tab_id={$tab->id}&action=showSettingsSectionTab&worker_id={$worker->id}&tab={$tab_name}{/devblocks_url}">{"common.$tab_name"|devblocks_translate|capitalize}</a></li>
 		{/foreach}
 	</ul>
 </div>


### PR DESCRIPTION
o.k. attempt 1001:

added a prefix "common." to the tab-name. the name of every hard-coded tab already exist as "common._tab-name_". originally, the translation- manager looked for an id _tab-name_, which didn't exist 

as long as the hard-coded list of tabs in line 5 won't be modified, this should work