### PR TITLE
Implement OPER_IS_NULL when searching kb_article by category

### DIFF
--- a/features/cerberusweb.kb/api/dao/kb_article.php
+++ b/features/cerberusweb.kb/api/dao/kb_article.php
@@ -614,6 +614,13 @@ class SearchFields_KbArticle extends DevblocksSearchFields {
 							implode(',', $category_ids)
 						);
 						break;
+						
+					case DevblocksSearchCriteria::OPER_IS_NULL:
+						return sprintf("NOT EXISTS (SELECT * FROM kb_article_to_category WHERE kb_article_to_category.kb_article_id=%s)", 
+							self::getPrimaryKey()
+						);
+						break;
+						
 				}
 				return 0;
 				break;


### PR DESCRIPTION
This is used to populate the default "Uncategorized" view - without the implementation we fall through to return literal "0", and never match anything.

In particular, this prevents articles from being orphaned from the UI.