### PR TITLE
fix issue where json encoded array was encoding twice

### DIFF
--- a/features/cerberusweb.core/api/dao/group.php
+++ b/features/cerberusweb.core/api/dao/group.php
@@ -2237,7 +2237,7 @@ class Context_Group extends Extension_DevblocksContext implements IDevblocksCont
 			
 				
 			case 'members':
-				$out_fields[DAO_Group::_MEMBERS] = json_encode($value);
+				$out_fields[DAO_Group::_MEMBERS] = $value;
 				break;
 		}
 		


### PR DESCRIPTION
based on documentation https://cerb.ai/docs/records/types/group/#records-api members are supposed to be JSON-encoded array. this fix removed the line that was encoding the already encoded array. 