### PR TITLE
Add version 8_ of elastic search that removes _doc mapping from uri

### DIFF
--- a/libs/devblocks/api/services/search.php
+++ b/libs/devblocks/api/services/search.php
@@ -91,7 +91,16 @@ class DevblocksSearchEngineElasticSearch extends Extension_DevblocksSearchEngine
 		
 		// [TODO] Paging
 		
-		if($version >= 6) {
+		if($version >= 8) {
+			$url = sprintf("%s/%s_%s/_search?q=%s&_source=false&size=%d&default_operator=OR&filter_path=%s",
+				$base_url,
+				rawurlencode($index),
+				rawurlencode($type),
+				rawurlencode($query),
+				$limit,
+				rawurlencode('took,hits.total,hits.hits._id')
+			);
+		} else if($version >= 6) {
 			// [TODO] Phase out filter_path?
 			$url = sprintf("%s/%s_%s/_doc/_search?q=%s&_source=false&size=%d&default_operator=OR&filter_path=%s",
 				$base_url,

--- a/libs/devblocks/templates/search_engine/elasticsearch.tpl
+++ b/libs/devblocks/templates/search_engine/elasticsearch.tpl
@@ -21,7 +21,8 @@
 	<b>Version:</b>
 	<p style="margin-left:5px;">
 		<label><input type="radio" name="params[{$engine->id}][version]" value="5" {if $engine_params.version != '6'}checked="checked"{/if}> 5.x or earlier</label>
-		<label><input type="radio" name="params[{$engine->id}][version]" value="6" {if $engine_params.version == '6'}checked="checked"{/if}> 6.x or later</label>
+		<label><input type="radio" name="params[{$engine->id}][version]" value="6" {if $engine_params.version == '6'}checked="checked"{/if}> 6.x to 7.x</label>
+		<label><input type="radio" name="params[{$engine->id}][version]" value="8" {if $engine_params.version == '8'}checked="checked"{/if}> 8.x or later</label>
 	</p>
 	
 	<b>Search index:</b>


### PR DESCRIPTION
@jstanden It Looks like in Elastic search 8 they removed `_doc`. There might be other issues but this is a breaking. I will update this as I find more.