### PR TITLE
Return $privs not void for "all" perms check

### DIFF
--- a/features/cerberusweb.core/api/dao/worker_role.php
+++ b/features/cerberusweb.core/api/dao/worker_role.php
@@ -340,7 +340,7 @@ class DAO_WorkerRole extends Cerb_ORMHelper {
 					case 'all':
 						$privs = ['*' => []];
 						$cache->save($privs, self::_CACHE_WORKER_PRIVS_PREFIX.$worker_id);
-						return;
+						return $privs;
 						
 					case 'itemized':
 						$role_privs = array_fill_keys($role->getPrivs(), []);


### PR DESCRIPTION
When `DAO_Worker::hasPriv()` is called with
e.g. `'contexts.cerberusweb.contexts.ticket.create'` in `PageSection_ProfilesDraft::_profileAction_saveComposePeek()`, and the worker is not a super-user but is in a role with "All" permissions (e.g. "Default"), the caller checks for the privilege key "*", which is not set if there's a short-circuit void return like this.  It looks to me like returning the `$privs` object as soon as the loop hits a role with "all"/"everything" privileges was what was actually intended.