### PR TITLE
add new sort order, and a way to go back to old order

### DIFF
--- a/features/cerberusweb.core/api/profiles/widgets/ticket/conversation.php
+++ b/features/cerberusweb.core/api/profiles/widgets/ticket/conversation.php
@@ -45,7 +45,7 @@ class ProfileWidget_TicketConvo extends Extension_ProfileWidget {
 		$mail_reply_format = DAO_WorkerPref::get($active_worker->id, 'mail_reply_format', '');
 		
 		if($mail_always_read_all) {
-			$display_options['expand_all'] = 1;
+			$display_options['expand_all'] = (int) $mail_always_read_all;
 		} else if(array_key_exists('expand_all', $_POST)) {
 			$display_options['expand_all'] = DevblocksPlatform::importGPC($_POST['expand_all'], 'bit', 0);
 		}
@@ -299,7 +299,8 @@ class ProfileWidget_TicketConvo extends Extension_ProfileWidget {
 			[$this, '_sortTimeline']
 		);
 		
-		if($display_options['expand_all'] ?? 0) {
+		$expand_all = $display_options['expand_all'] ?? 0;
+		if($expand_all === 1) {
 			$convo_timeline = array_reverse($convo_timeline, true);
 		}
 		

--- a/features/cerberusweb.core/strings.xml
+++ b/features/cerberusweb.core/strings.xml
@@ -5404,9 +5404,19 @@ For example: *receipt*</seg>
 				<seg>Always show plaintext messages (disable HTML)</seg>
 			</tuv>
 		</tu>
+		<tu tuid="preferences.account.mail.readall.default">
+			<tuv xml:lang="en_US">
+				<seg>Do not expand messages</seg>
+			</tuv>
+		</tu>
 		<tu tuid="preferences.account.mail.readall">
 			<tuv xml:lang="en_US">
 				<seg>Always use 'read all' mode (expand messages and sort chronologically)</seg>
+			</tuv>
+		</tu>
+		<tu tuid="preferences.account.mail.readall.reverse">
+			<tuv xml:lang="en_US">
+				<seg>Always use 'read all' mode (expand messages and sort newest first)</seg>
 			</tuv>
 		</tu>
 		<tu tuid="preferences.account.mail.reply_textbox_size">

--- a/features/cerberusweb.core/templates/internal/profiles/tabs/worker/settings/tabs/mail.tpl
+++ b/features/cerberusweb.core/templates/internal/profiles/tabs/worker/settings/tabs/mail.tpl
@@ -11,7 +11,9 @@
 <b>{'preferences.account.mail.display'|devblocks_translate}</b>
 <div style="margin:0px 0px 10px 10px;">
 	<label><input type="checkbox" name="mail_disable_html_display" value="1" {if $prefs.mail_disable_html_display}checked{/if}> {'preferences.account.mail.display.disable_html'|devblocks_translate}</label><br>
-	<label><input type="checkbox" name="mail_always_read_all" value="1" {if $prefs.mail_always_read_all}checked{/if}> {'preferences.account.mail.readall'|devblocks_translate}</label><br>
+	<label><input type="radio" name="mail_always_read_all" value="0" {if not $prefs.mail_always_read_all || $prefs.mail_always_read_all === '0'}checked{/if}> {'preferences.account.mail.readall.default'|devblocks_translate}</label><br>
+	<label><input type="radio" name="mail_always_read_all" value="1" {if $prefs.mail_always_read_all === '1'}checked{/if}> {'preferences.account.mail.readall'|devblocks_translate}</label><br>
+	<label><input type="radio" name="mail_always_read_all" value="2" {if $prefs.mail_always_read_all === '2'}checked{/if}> {'preferences.account.mail.readall.reverse'|devblocks_translate}</label><br>
 </div>
 
 <b>{'preferences.account.mail.reply_button'|devblocks_translate}</b>


### PR DESCRIPTION
I thought this might be useful for others as well. Our team wants to see all message, but they like to see newest messages first. Radio buttons looked to be the easiest so I also added default option. I know I skipped the place where the messages actually get expended, but since 2 will also equal true figured it be fine. Let me know if I need to adjust anything