### PR TITLE
add comma at the end of input if none is provided

### DIFF
--- a/features/cerberusweb.core/templates/display/rpc/reply.tpl
+++ b/features/cerberusweb.core/templates/display/rpc/reply.tpl
@@ -375,7 +375,16 @@ $(function() {
 					e.preventDefault();
 			})
 			;
-		
+			
+		$frm
+			.find('[name="to"], [name="cc"], [name="bcc"]')
+			.keydown(function(e) {
+				$value = e.target.value;
+				if(32 === e.which && !$value.endsWith(','))
+					e.target.value = $value.trimEnd() + ','
+			})
+			;
+
 		$frm.find('.cerb-peek-trigger').cerbPeekTrigger();
 		$frm.find('button.chooser-abstract').cerbChooserTrigger();
 		


### PR DESCRIPTION
This is more or less a quick fix, but no validation if staff types in two emails without a comma in any of the 3 fields shown here. You can hit send and it will never send to anyone as far as I am aware. To headers are missing and no error anywhere. This adds a comma on space key if it is needed.