### PR TITLE
show columns if user has premissions

### DIFF
--- a/features/cerberusweb.core/api/uri/profiles/profile_tab.php
+++ b/features/cerberusweb.core/api/uri/profiles/profile_tab.php
@@ -231,7 +231,7 @@ class PageSection_ProfilesProfileTab extends Extension_PageSection {
 	private function _profileAction_getContextColumnsJson() {
 		$active_worker = CerberusApplication::getActiveWorker();
 		
-		if(!$active_worker->is_superuser)
+		if(!$active_worker->hasPriv('contexts.cerberusweb.contexts.profile.tab.create'))
 			DevblocksPlatform::dieWithHttpError(null, 403);
 		
 		$context = DevblocksPlatform::importGPC($_REQUEST['context'] ?? null, 'string', null);


### PR DESCRIPTION
Talking with Dan about this, and im not 100% of what premission this should have, but when non user creates widget it wont load the columns and shows error, but still allows you to create the widget, since this just rejects the columns loading