### PR TITLE
prevent past dates from being used when setting reopen date

### DIFF
--- a/features/cerberusweb.core/api/uri/internal/calendars.php
+++ b/features/cerberusweb.core/api/uri/internal/calendars.php
@@ -106,6 +106,10 @@ class PageSection_InternalCalendars extends Extension_PageSection {
 			echo json_encode(false);
 			return;
 		}
+
+		// if date is in the past, reopen in a minute
+		if ($timestamp <= strtotime('now'))
+			$timestamp = strtotime('+1 minute');
 		
 		$results['timestamp'] = $timestamp;
 		$results['to_string'] = $date->formatTime(null, $timestamp);

--- a/features/cerberusweb.core/resources/js/cerberus.js
+++ b/features/cerberusweb.core/resources/js/cerberus.js
@@ -1490,8 +1490,10 @@ $.fn.cerbDateInputHelper = function(options) {
 			dateFormat: 'D, d M yy',
 			defaultDate: 'D, d M yy',
 			numberOfMonths: 1,
+			minDate: 0,
 			onSelect: function(dateText, inst) {
 				inst.input.addClass('changed').focus();
+				$(this).trigger('send');
 			}
 		});
 		


### PR DESCRIPTION
if today is selected, it triggers +1 minute so it doesn't reopen right away. fixes issue #1791 